### PR TITLE
separating ALLOWED_HOSTS

### DIFF
--- a/app/weddingproject/settings.py
+++ b/app/weddingproject/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = config('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', default=[], cast=lambda v: [s.strip() for s in v.split(',')] if (v and v!='[]') else [])
 
 
 # Application definition


### PR DESCRIPTION
### This task was created to separate more environment variables in order to make things a bit smoothier by keeping this type of variable separated in only one file, i.e. in `.env`.

Variable `ALLOWED_HOSTS` was set to `[]`. Now, it is an environment variable set to:
`ALLOWED_HOSTS = config('ALLOWED_HOSTS', default=[], cast=lambda v: [s.strip() for s in v.split(',')] if (v and v!='[]') else [])`.

You don't need to put anything in `.env`, because if there is no `ALLOWED_HOSTS` in `.env`, this variable will assume its default value, i.e. `ALLOWED_HOSTS = []`.

---
We could also separate `DEBUG` and it would be equal to:
`DEBUG = config('DEBUG', default=False, cast=bool)`.
However, we would have to set `DEBUG = True` in `.env` while it's not in production. Since this is kinda bothersome, it's makes more sense to just separate `ALLOWED_HOSTS`, at least for now.